### PR TITLE
Feat: 리뷰 관련 API 생성

### DIFF
--- a/src/apis/supabase/getReviews.ts
+++ b/src/apis/supabase/getReviews.ts
@@ -1,0 +1,26 @@
+import { useLocation } from 'react-router-dom';
+
+import { unitripSupabase } from '@/utils/supabaseClient';
+
+const getReviews = async () => {
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const place = queryParams.get('contentId');
+
+  const { data, error } = await unitripSupabase
+    .from('REVIEW')
+    .select('*, USER(name)')
+    .eq('place', place);
+
+  if (error) {
+    throw new Error('서버에 문제가 있습니다');
+  }
+
+  /*
+   ** data는 리뷰들을 string[]에 저장
+   ** 각 리뷰들의 타입은 ReviewResProps 타입을 갖고 있음
+   */
+  return data;
+};
+
+export default getReviews;

--- a/src/apis/supabase/postImgReview.ts
+++ b/src/apis/supabase/postImgReview.ts
@@ -1,0 +1,35 @@
+import { unitripSupabase } from '@/utils/supabaseClient';
+
+const postImgReview = async (imgs: File[]) => {
+  const imgUrls: string[] = [];
+
+  // 각 파일을 Supabase Storage에 업로드
+  for (const img of imgs) {
+    const { error: uploadError } = await unitripSupabase.storage
+      .from('REVIEW_IMAGES')
+      .upload(`images/${img.name}`, img);
+
+    if (uploadError) {
+      throw new Error('이미지 업로드 과정에서 에러가 발생했습니다');
+    }
+
+    // 업로드한 파일의 URL 생성
+    const { data } = unitripSupabase.storage
+      .from('REVIEW_IMAGES')
+      .getPublicUrl(`images/${img.name}`);
+
+    if (data) {
+      const { publicUrl } = data;
+      imgUrls.push(publicUrl);
+    }
+  }
+
+  // 파일 URL을 데이터베이스에 저장
+  const { error: dbError } = await unitripSupabase.from('USER').insert(imgUrls);
+
+  if (dbError) {
+    throw new Error('서버에 문제가 있습니다');
+  }
+};
+
+export default postImgReview;

--- a/src/apis/supabase/postReview.ts
+++ b/src/apis/supabase/postReview.ts
@@ -1,0 +1,46 @@
+import { useLocation } from 'react-router-dom';
+
+import { unitripSupabase } from '@/utils/supabaseClient';
+
+import postImgReview from './postImgReview';
+
+interface postReviewProps {
+  rate: number;
+  description: string;
+  convenience: string[];
+  imgs: File[];
+}
+
+const postReview = async ({
+  rate,
+  description,
+  convenience,
+  imgs,
+}: postReviewProps) => {
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const place = queryParams.get('contentId');
+
+  const writer = sessionStorage.getItem('kakao_id');
+
+  const { error } = await unitripSupabase
+    .from('REVIEW')
+    .insert([
+      {
+        place,
+        writer,
+        rate,
+        description,
+        convenience,
+      },
+    ])
+    .select();
+
+  await postImgReview(imgs);
+
+  if (error) {
+    throw new Error('서버에 문제가 있습니다');
+  }
+};
+
+export default postReview;

--- a/src/types/supabaseAPI.ts
+++ b/src/types/supabaseAPI.ts
@@ -1,0 +1,9 @@
+export interface ReviewResProps {
+  rate: number;
+  description: string;
+  convenience: string[];
+  imgUrls: string[];
+  USER: {
+    name: string;
+  };
+}


### PR DESCRIPTION
<!-- 이슈 제목과 동일하게 PR의 제목은 "구현 타입: 구현내용 " -->
close #46 

<br />

## ✅ 완료 태스크
- 리뷰 받아오기 api
- 리뷰 저장하기 api

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->
**쿼리파라미터로 `contentId`라는 파리미터명을 사용했습니다**

✅ `img storage`
저번에 회의한대로 presinged url 대신에 
supabase에서 자체적으로 제공하는 storage를 활용하여 개발하였습니다.
`REVIEW_IMAGES` 버킷에 이미지들을 모아놓을 예정입니다.

동시에 이미지 url을 db에 저장하여 불러올 때 편하게 예정입니다.
다만, 이미지 업로드에 시간이 조금 걸려서 스피너를 만들어야겠다는 생각이..듭니다.............

✅ get review
리뷰 받아올 때, 필요한 데이터 값들을 불러옵니다
타입 지정을 해줘서 좀 더 편하게 사용할 수 있도록 해봤는데 더 받아야되는 값이나 이렇게 하면 더 편할 것 같다 싶으면 말씀해주세요
```tsx
export interface ReviewResProps {
  rate: number;
  description: string;
  convenience: string[];
  imgUrls: string[];
  USER: {
    name: string;
  };
}
```

<br />
